### PR TITLE
入力情報クリアのボタンの追加 Vr.1.0

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-MainActivity.kt

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -3,8 +3,8 @@
   <component name="deploymentTargetSelector">
     <selectionStates>
       <SelectionState runConfigName="app">
-        <option name="selectionMode" value="DIALOG" />
-        <DropdownSelection timestamp="2024-09-25T09:23:16.757197Z">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2024-10-02T04:15:17.131324Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=/Users/user102/.android/avd/Pixel_5_API_31.avd" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    namespace = "com.example.tipcalculator"
+    namespace = "com.example.tipcaltulator"
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.example.tipcalculator"
+        applicationId = "com.example.tipcaltulator"
         minSdk = 24
         targetSdk = 34
         versionCode = 1

--- a/app/src/main/java/com/example/tipcalculator/MainActivity.kt
+++ b/app/src/main/java/com/example/tipcalculator/MainActivity.kt
@@ -2,9 +2,15 @@ package com.example.tipcalculator
 
 import com.example.tipcalculator.R
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+<<<<<<< Updated upstream
+=======
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+>>>>>>> Stashed changes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -30,6 +36,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+<<<<<<< Updated upstream
+=======
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+>>>>>>> Stashed changes
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
@@ -37,7 +48,9 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.tipcalculator.ui.theme.TipCalculatorTheme
+import com.example.tipcaltulator.R
 import java.text.NumberFormat
+
 
 
 class MainActivity : ComponentActivity() {
@@ -46,8 +59,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             TipCalculatorTheme {
-                Surface(
-                ) {
+                Surface {
                     TipCalculatorLayout()
 
                 }
@@ -64,6 +76,7 @@ fun TipCalculatorLayout() {
 
     val keyboardController = LocalSoftwareKeyboardController.current // キーボードコントローラ
     val focusRequester = remember { FocusRequester() }
+    val context = LocalContext.current // コンテキストを取得
     Column(
         modifier = Modifier
             .statusBarsPadding()
@@ -100,12 +113,29 @@ fun TipCalculatorLayout() {
             focusRequester.requestFocus() // フォーカスを移動
             keyboardController?.show()
         }) {
+<<<<<<< Updated upstream
             Text("Tip計算")
         }
 
         Spacer(modifier = Modifier.height(150.dp))
     }
 }
+=======
+            Text("キーボードを表示する")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = {amountInput = ""}
+        ) { Text(text = "入力情報をクリア") }
+
+        Spacer(modifier = Modifier.height(50.dp)) // 他のUI要素との間隔を確保
+
+
+
+        }
+    }
+
+
+>>>>>>> Stashed changes
 
 @Composable
 fun EditNumberField(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,10 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.5"
 activityCompose = "1.9.2"
 composeBom = "2024.04.01"
+navigationRuntimeKtx = "2.8.1"
+foundationAndroid = "1.7.2"
+foundationLayoutAndroid = "1.7.2"
+material3Android = "1.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +28,10 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "navigationRuntimeKtx" }
+androidx-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android", version.ref = "foundationAndroid" }
+androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
+androidx-material3-android = { group = "androidx.compose.material3", name = "material3-android", version.ref = "material3Android" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
### 概要

- 入力情報クリアするボタンをキーボード表示のボタンの下に追加しました

### 現状

- `git branch --set-upstream-to=origin/<remote-branch> <local-branch>`を行ったことでコードに不要な部分が追加されてしまった

### これから実施すること

- コードの不要な部分の削除
- 入力情報クリアボタンを押すことでテキストボックスの内容をクリアできるという機能部分の実現
<img width="286" alt="スクリーンショット 2024-10-02 14 32 35" src="https://github.com/user-attachments/assets/6d9f2501-330a-49c9-bf89-242673a992a3">

